### PR TITLE
Slider: graphical tweaks and control changes

### DIFF
--- a/include/LazyFollower.h
+++ b/include/LazyFollower.h
@@ -43,6 +43,7 @@ public:
 	LazyFollower();
 	void updateTarget(QVector<float> inputs);
 	void updateTarget(int index, float input);
+	float getTarget(int index);
 	void setFractionPerFrame(QVector<float> fracs);
 	void setFractionPerFrame(int index, float frac);
 

--- a/include/ModernSlider.h
+++ b/include/ModernSlider.h
@@ -27,6 +27,7 @@
 #include <QWidget>
 #include <QPainter>
 #include <QMouseEvent>
+#include <QWheelEvent>
 #include <QTimer>
 
 #include "LazyFollower.h"
@@ -46,6 +47,7 @@ protected:
 	virtual void mousePressEvent(QMouseEvent * event);
 	virtual void mouseMoveEvent(QMouseEvent * event);
 	virtual void mouseReleaseEvent(QMouseEvent * event);
+	virtual void wheelEvent(QWheelEvent * event);
 	virtual void leaveEvent(QEvent * event);
 	virtual void setFollowValues(QVector<float> values);
 
@@ -63,6 +65,8 @@ private:
 	int getHandleTop();
 	float getScaleFactor();
 	bool isMouseYInsideHandle(int y);
+	void tickUp();
+	void tickDown();
 	bool m_inDragOperation;
 	int m_mouseYForTick;
 	QTimer * m_nudgeTimer;

--- a/include/ModernSlider.h
+++ b/include/ModernSlider.h
@@ -61,8 +61,10 @@ private:
 	bool isMouseYInsideHandle(int y);
 	bool m_inDragOperation;
 	float m_mouseDistanceFromHandleTop;
+	float m_potentialNewValue;
 	LazyFollower* m_lazyFollower;
 	QColor m_highlightColor;
+	QPoint m_storedCursorPos;
 
 	static const int s_handleHeight = 31;
 	static const int s_handleWidth = 18;
@@ -74,4 +76,6 @@ private:
 	static const int s_handleOutsideColorLightClicked = 116;
 	static const int s_handleOutsideColorDark = 84;
 	static const int s_handleOutsideColorDarkClicked = 97;
+
+	constexpr static const float s_movementScalingFactor = 1/700.0;
 };

--- a/include/ModernSlider.h
+++ b/include/ModernSlider.h
@@ -68,10 +68,10 @@ private:
 	static const int s_handleWidth = 18;
 	static const int s_handleInsideColorLight = 94;
 	static const int s_handleInsideColorLightClicked = 102;
-	static const int s_handleInsideColorDark = 79;
-	static const int s_handleInsideColorDarkClicked = 91;
-	static const int s_handleOutsideColorLight = 98;
-	static const int s_handleOutsideColorLightClicked = 113;
+	static const int s_handleInsideColorDark = 73;
+	static const int s_handleInsideColorDarkClicked = 85;
+	static const int s_handleOutsideColorLight = 101;
+	static const int s_handleOutsideColorLightClicked = 116;
 	static const int s_handleOutsideColorDark = 84;
 	static const int s_handleOutsideColorDarkClicked = 97;
 };

--- a/include/ModernSlider.h
+++ b/include/ModernSlider.h
@@ -74,6 +74,7 @@ private:
 	float m_potentialNewValue;
 	LazyFollower* m_lazyFollower;
 	QColor m_highlightColor;
+	QColor m_grooveHighlightColor;
 	QPoint m_storedCursorPos;
 
 	static const int s_handleHeight = 31;

--- a/include/ModernSlider.h
+++ b/include/ModernSlider.h
@@ -27,6 +27,7 @@
 #include <QWidget>
 #include <QPainter>
 #include <QMouseEvent>
+#include <QTimer>
 
 #include "LazyFollower.h"
 
@@ -48,6 +49,9 @@ protected:
 	virtual void leaveEvent(QEvent * event);
 	virtual void setFollowValues(QVector<float> values);
 
+protected slots:
+	void updateTickValue();
+
 private:
 	QPainter m_canvas;
 	float m_value;
@@ -60,6 +64,8 @@ private:
 	float getScaleFactor();
 	bool isMouseYInsideHandle(int y);
 	bool m_inDragOperation;
+	int m_mouseYForTick;
+	QTimer * m_nudgeTimer;
 	float m_mouseDistanceFromHandleTop;
 	float m_potentialNewValue;
 	LazyFollower* m_lazyFollower;
@@ -77,5 +83,6 @@ private:
 	static const int s_handleOutsideColorDark = 84;
 	static const int s_handleOutsideColorDarkClicked = 97;
 
-	constexpr static const float s_movementScalingFactor = 1/700.0;
+	constexpr static const float s_tickAmt = 0.05;
+	constexpr static const float s_movementScalingFactor = 1/350.0;
 };

--- a/src/gui/ModernUI/LazyFollower.cpp
+++ b/src/gui/ModernUI/LazyFollower.cpp
@@ -62,6 +62,11 @@ void LazyFollower::updateTarget(int index, float input)
 	m_stopped = false;
 }
 
+float LazyFollower::getTarget(int index)
+{
+	return m_currentTargets[index];
+}
+
 void LazyFollower::setFractionPerFrame(QVector<float> fracs)
 {
 	m_fracs = fracs;

--- a/src/gui/ModernUI/ModernSlider.cpp
+++ b/src/gui/ModernUI/ModernSlider.cpp
@@ -71,22 +71,26 @@ void ModernSlider::paintEvent(QPaintEvent *event)
 
 	QRectF handleBackground = QRectF(QPointF(0, handleTop), QSizeF(s_handleWidth, s_handleHeight));
 	m_canvas.setBrush(QBrush(QColor(43, 43, 43)));
-	m_canvas.drawRoundedRect(handleBackground, 1, 1);
+	m_canvas.drawRoundedRect(handleBackground, 2, 2);
 
 	QRectF handleOutside = QRectF(QPointF(1, handleTop + 1), QSizeF(s_handleWidth - 2, s_handleHeight - 2));
 	QLinearGradient handleOutsideGrad = QLinearGradient(QPointF(0, handleTop), QPointF(0, handleTop + s_handleHeight));
 	handleOutsideGrad.setColorAt(0, QColor(m_handleOutsideColorLight, m_handleOutsideColorLight, m_handleOutsideColorLight));
 	handleOutsideGrad.setColorAt(1, QColor(m_handleOutsideColorDark, m_handleOutsideColorDark, m_handleOutsideColorDark));
 	m_canvas.setBrush(QBrush(handleOutsideGrad));
-	m_canvas.drawRoundedRect(handleOutside, 1, 1);
+	m_canvas.drawRoundedRect(handleOutside, 2, 2);
 
 	QRectF handleInside = QRectF(QPointF(1, handleTop + s_handleHeight*m_handleSquish), QPointF(s_handleWidth - 1, handleTop + s_handleHeight - (m_handleSquish*s_handleHeight)));
 	int lightShade = m_handleInsideColorLight;
 	int darkShade = m_handleInsideColorDark;
 	QLinearGradient handleInsideGrad = QLinearGradient(QPointF(0, handleTop + (m_handleSquish*s_handleHeight)), QPointF(0, handleTop + s_handleHeight - (m_handleSquish*s_handleHeight)));
-	handleInsideGrad.setColorAt(0, QColor(darkShade, darkShade, darkShade));
+
+	// Slight color increase for the top of the handle inside
+	// yay shading
+	handleInsideGrad.setColorAt(0, QColor(darkShade + 5, darkShade + 5, darkShade + 5));
 	handleInsideGrad.setColorAt(0.5, QColor(lightShade, lightShade, lightShade));
 	handleInsideGrad.setColorAt(1, QColor(darkShade, darkShade, darkShade));
+
 	m_canvas.setBrush(QBrush(handleInsideGrad));
 	m_canvas.drawRoundedRect(handleInside, 1, 1);
 

--- a/src/gui/ModernUI/ModernSlider.cpp
+++ b/src/gui/ModernUI/ModernSlider.cpp
@@ -141,7 +141,7 @@ void ModernSlider::mouseMoveEvent(QMouseEvent *event)
 			m_lazyFollower->updateTarget(0, m_potentialNewValue);
 	}
 
-	if (isMouseYInsideHandle(event->y()))
+	if (m_inDragOperation || isMouseYInsideHandle(event->y()))
 	{
 		m_lazyFollower->updateTarget(5, 1 - (s_handleHeight - 5)/(float)s_handleHeight);
 	}

--- a/src/gui/ModernUI/ModernSlider.cpp
+++ b/src/gui/ModernUI/ModernSlider.cpp
@@ -160,28 +160,14 @@ void ModernSlider::updateTickValue()
 {
 	int handleTop = getHandleTop();
 	int handleBottom = handleTop + s_handleHeight/getScaleFactor();
-	float newTarget;
-	bool wasNewTargetSet = false;
 
 	if (m_mouseYForTick < handleTop)
 	{
-		newTarget = m_value + s_tickAmt;
-		wasNewTargetSet = true;
+		tickUp();
 	}
 	else if (m_mouseYForTick > handleBottom)
 	{
-		newTarget = m_value - s_tickAmt;
-		wasNewTargetSet = true;
-	}
-
-	if (wasNewTargetSet)
-	{
-		if (newTarget > 1)
-			m_lazyFollower->updateTarget(0, 1);
-		else if (newTarget < 0)
-			m_lazyFollower->updateTarget(0, 0);
-		else
-			m_lazyFollower->updateTarget(0, newTarget);
+		tickDown();
 	}
 }
 
@@ -214,6 +200,37 @@ void ModernSlider::mouseReleaseEvent(QMouseEvent *event)
 void ModernSlider::leaveEvent(QEvent *event)
 {
 	m_lazyFollower->updateTarget(5, 1 - (s_handleHeight - 3)/(float)s_handleHeight);
+}
+
+void ModernSlider::wheelEvent(QWheelEvent *event)
+{
+	float y = event->angleDelta().y();
+	if (y > 0)
+		tickUp();
+	else
+		tickDown();
+}
+
+void ModernSlider::tickUp()
+{
+	float newTarget = m_lazyFollower->getTarget(0) + s_tickAmt;
+	if (newTarget > 1)
+		m_lazyFollower->updateTarget(0, 1);
+	else if (newTarget < 0)
+		m_lazyFollower->updateTarget(0, 0);
+	else
+		m_lazyFollower->updateTarget(0, newTarget);
+}
+
+void ModernSlider::tickDown()
+{
+	float newTarget = m_lazyFollower->getTarget(0) - s_tickAmt;
+	if (newTarget > 1)
+		m_lazyFollower->updateTarget(0, 1);
+	else if (newTarget < 0)
+		m_lazyFollower->updateTarget(0, 0);
+	else
+		m_lazyFollower->updateTarget(0, newTarget);
 }
 
 bool ModernSlider::isMouseYInsideHandle(int y)

--- a/src/gui/ModernUI/ModernSlider.cpp
+++ b/src/gui/ModernUI/ModernSlider.cpp
@@ -145,13 +145,15 @@ void ModernSlider::mouseMoveEvent(QMouseEvent *event)
 
 void ModernSlider::mouseReleaseEvent(QMouseEvent *event)
 {
-	this->setCursor(Qt::ArrowCursor);
+	if (m_inDragOperation) {
+		this->setCursor(Qt::ArrowCursor);
 
-	// Set cursor position to the middle of the handle
-	QCursor c = cursor();
-	float scaleFactor = 1 - getScaleFactor();
-	c.setPos(this->mapToGlobal(QPoint(width()/2, (s_handleHeight/scaleFactor) + (1 - m_value)*height()*scaleFactor)));
-	setCursor(c);
+		// Set cursor position to the middle of the handle
+		QCursor c = cursor();
+		float scaleFactor = 1 - getScaleFactor();
+		c.setPos(this->mapToGlobal(QPoint(width()/2, (s_handleHeight/scaleFactor) + (1 - m_value)*height()*scaleFactor)));
+		setCursor(c);
+	}
 
 	m_inDragOperation = false;
 	m_lazyFollower->updateTarget(1, s_handleInsideColorLight);

--- a/src/gui/ModernUI/ModernSlider.cpp
+++ b/src/gui/ModernUI/ModernSlider.cpp
@@ -150,8 +150,12 @@ void ModernSlider::mouseReleaseEvent(QMouseEvent *event)
 
 		// Set cursor position to the middle of the handle
 		QCursor c = cursor();
-		float scaleFactor = 1 - getScaleFactor();
-		c.setPos(this->mapToGlobal(QPoint(width()/2, (s_handleHeight/scaleFactor) + (1 - m_value)*height()*scaleFactor)));
+		float scaleFactor = getScaleFactor();
+
+		float handleHeight = s_handleHeight/scaleFactor;
+
+		auto y = handleHeight*0.5 + (1 - m_value) * (height() - handleHeight);
+		c.setPos(this->mapToGlobal(QPoint(width()/2, y)));
 		setCursor(c);
 	}
 

--- a/src/gui/ModernUI/ModernSlider.cpp
+++ b/src/gui/ModernUI/ModernSlider.cpp
@@ -38,6 +38,7 @@ ModernSlider::ModernSlider(QWidget *_parent, const QString &_name):
 	m_handleSquish = 1 - (s_handleHeight - 3)/(float)s_handleHeight;
 	m_lazyFollower = new LazyFollower(this, 6, {m_value, m_handleInsideColorLight, m_handleInsideColorDark, m_handleOutsideColorLight, m_handleOutsideColorDark, m_handleSquish}, {0.62, 0.6, 0.6, 0.6, 0.6, 0.85});
 	m_highlightColor = QColor(22, 156, 116);
+	m_grooveHighlightColor = QColor(25, 126, 96);
 	m_nudgeTimer = new QTimer(this);
 	m_nudgeTimer->setInterval(70);
 	connect(m_nudgeTimer, SIGNAL(timeout()), this, SLOT(updateTickValue()));
@@ -64,7 +65,7 @@ void ModernSlider::paintEvent(QPaintEvent *event)
 	m_canvas.drawRect(grooveBackground);
 
 	QRect grooveHighlight = QRect(QPoint(s_handleWidth/2 - 1, handleTop + s_handleHeight/2), QPoint(s_handleWidth/2, height() * yScaleFactor - 2));
-	m_canvas.setBrush(QBrush(m_highlightColor));
+	m_canvas.setBrush(QBrush(m_grooveHighlightColor));
 	m_canvas.drawRect(grooveHighlight);
 
 
@@ -263,12 +264,14 @@ float ModernSlider::getScaleFactor()
 
 void ModernSlider::setMuted()
 {
-	m_highlightColor = QColor(49, 49, 49);
+	m_grooveHighlightColor = QColor(49, 49, 49);
+	m_highlightColor = QColor(43, 43, 43);
 	update();
 }
 
 void ModernSlider::setUnmuted()
 {
 	m_highlightColor = QColor(22, 156, 116);
+	m_grooveHighlightColor = QColor(25, 126, 96);
 	update();
 }


### PR DESCRIPTION
Will close https://github.com/SecondFlight/lmms/issues/18 and https://github.com/SecondFlight/lmms/issues/38

Additionally, this moves to a control mechanism that blanks out the mouse and maps y movement directly to slider value. This lets us control how fast the slider moves in comparison to mouse movements and allows for more precise control of the slider.

This PR will also eventually include a feature that pauses the slider at 0db, as well as a way to move the slider slowly when clicking and holding on an area that is not the slider.